### PR TITLE
Remove NFS mount options overrides

### DIFF
--- a/group_vars/tag_Environment_live.yml
+++ b/group_vars/tag_Environment_live.yml
@@ -143,7 +143,5 @@ nfsmounts:
     src: "ipo-file-svm-lif-be1.internal.ch:scanning"
   - path: "/data1/home/scanning"
     src: "ipo-file-svm-lif-be1.internal.ch:tiffexport"
-    opts: "soft,bg"
   - path: "/data1/image/scud"
     src: "ipo-file-svm-lif-be1.internal.ch:tiffexport"
-    opts: "soft,bg"


### PR DESCRIPTION
These changes remove unnecessary overrides for two NFS mounts that use the same underlying device and will fallback to the default option set of `hard,bg`.