### PR TITLE
Add resources for presenter data transfer mechanism

### DIFF
--- a/groups/fil/data.tf
+++ b/groups/fil/data.tf
@@ -1,0 +1,97 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_roles" "sso_administrator" {
+  name_regex  = "AWSReservedSSO_AdministratorAccess.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/${var.region}"
+}
+
+data "aws_iam_user" "concourse" {
+    user_name = "concourse-platform"
+}
+
+data "aws_iam_policy_document" "fil" {
+  statement {
+    sid = "EnableIAMPolicies"
+
+    principals {
+      type        = "AWS"
+      identifiers =["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "AllowAccessForKeyAdministrators"
+
+    principals {
+      type        = "AWS"
+      identifiers = local.kms_key_administrator_arns
+    }
+
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  dynamic "statement" {
+    for_each = var.create_ef_presenter_data_bucket ? [1] : []
+
+    content {
+      sid = "AllowDecryptionOperationsForThesePrincipals"
+
+      principals {
+        type        = "AWS"
+        identifiers = var.ef_presenter_data_read_only_principal_arns
+      }
+
+      actions = ["kms:Decrypt"]
+
+      resources = ["*"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "ef_presenter_data_bucket" {
+  dynamic "statement" {
+    for_each = var.create_ef_presenter_data_bucket ? [1] : []
+
+    content {
+      sid = "AllowListBucketFromThesePrincipals"
+      
+      principals {
+        type        = "AWS"
+        identifiers = var.ef_presenter_data_read_only_principal_arns
+      }
+
+      actions = [
+      "s3:ListBucket"
+      ]
+
+      resources = [
+        aws_s3_bucket.ef_presenter_data[0].arn
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.create_ef_presenter_data_bucket ? [1] : []
+
+    content {
+      sid = "AllowReadAccessFromThesePrincipals"
+
+      principals {
+        type        = "AWS"
+        identifiers = var.ef_presenter_data_read_only_principal_arns
+      }
+
+      actions = [
+        "s3:GetObject",
+      ]
+
+      resources = [
+        "${aws_s3_bucket.ef_presenter_data[0].arn}/*",
+      ]
+    }
+  }
+}

--- a/groups/fil/data.tf
+++ b/groups/fil/data.tf
@@ -35,14 +35,14 @@ data "aws_iam_policy_document" "fil" {
   }
 
   dynamic "statement" {
-    for_each = var.create_ef_presenter_data_bucket ? [1] : []
+    for_each = var.ef_presenter_data_bucket_enabled ? [1] : []
 
     content {
       sid = "AllowDecryptionOperationsForThesePrincipals"
 
       principals {
         type        = "AWS"
-        identifiers = var.ef_presenter_data_read_only_principal_arns
+        identifiers = var.ef_presenter_data_read_only_principals
       }
 
       actions = ["kms:Decrypt"]
@@ -54,14 +54,14 @@ data "aws_iam_policy_document" "fil" {
 
 data "aws_iam_policy_document" "ef_presenter_data_bucket" {
   dynamic "statement" {
-    for_each = var.create_ef_presenter_data_bucket ? [1] : []
+    for_each = var.ef_presenter_data_bucket_enabled ? [1] : []
 
     content {
       sid = "AllowListBucketFromThesePrincipals"
 
       principals {
         type        = "AWS"
-        identifiers = var.ef_presenter_data_read_only_principal_arns
+        identifiers = var.ef_presenter_data_read_only_principals
       }
 
       actions = [
@@ -75,14 +75,14 @@ data "aws_iam_policy_document" "ef_presenter_data_bucket" {
   }
 
   dynamic "statement" {
-    for_each = var.create_ef_presenter_data_bucket ? [1] : []
+    for_each = var.ef_presenter_data_bucket_enabled ? [1] : []
 
     content {
       sid = "AllowReadAccessFromThesePrincipals"
 
       principals {
         type        = "AWS"
-        identifiers = var.ef_presenter_data_read_only_principal_arns
+        identifiers = var.ef_presenter_data_read_only_principals
       }
 
       actions = [

--- a/groups/fil/data.tf
+++ b/groups/fil/data.tf
@@ -6,7 +6,7 @@ data "aws_iam_roles" "sso_administrator" {
 }
 
 data "aws_iam_user" "concourse" {
-    user_name = "concourse-platform"
+  user_name = "concourse-platform"
 }
 
 data "aws_iam_policy_document" "fil" {
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "fil" {
 
     principals {
       type        = "AWS"
-      identifiers =["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
 
     actions   = ["kms:*"]
@@ -58,14 +58,14 @@ data "aws_iam_policy_document" "ef_presenter_data_bucket" {
 
     content {
       sid = "AllowListBucketFromThesePrincipals"
-      
+
       principals {
         type        = "AWS"
         identifiers = var.ef_presenter_data_read_only_principal_arns
       }
 
       actions = [
-      "s3:ListBucket"
+        "s3:ListBucket"
       ]
 
       resources = [

--- a/groups/fil/iam.tf
+++ b/groups/fil/iam.tf
@@ -1,9 +1,9 @@
 module "instance_profile" {
   source = "git@github.com:companieshouse/terraform-modules//aws/instance_profile?ref=tags/1.0.62"
-  name = "${var.service_subtype}-${var.service}-profile"
+  name   = "${var.service_subtype}-${var.service}-profile"
 
-  cw_log_group_arns = [for log_group in merge(aws_cloudwatch_log_group.tuxedo, {"cloudwatch" = aws_cloudwatch_log_group.cloudwatch}) : log_group.arn]
-  enable_SSM = true
-  kms_key_refs = local.instance_profile_kms_key_access_ids
-  s3_buckets_write = local.instance_profile_writable_buckets
+  cw_log_group_arns = [for log_group in merge(aws_cloudwatch_log_group.tuxedo, { "cloudwatch" = aws_cloudwatch_log_group.cloudwatch }) : log_group.arn]
+  enable_SSM        = true
+  kms_key_refs      = local.instance_profile_kms_key_access_ids
+  s3_buckets_write  = local.instance_profile_writable_buckets
 }

--- a/groups/fil/iam.tf
+++ b/groups/fil/iam.tf
@@ -4,8 +4,6 @@ module "instance_profile" {
 
   cw_log_group_arns = [for log_group in merge(aws_cloudwatch_log_group.tuxedo, {"cloudwatch" = aws_cloudwatch_log_group.cloudwatch}) : log_group.arn]
   enable_SSM = true
-  kms_key_refs = [
-    local.ssm_kms_key_id
-  ]
-  s3_buckets_write = [local.session_manager_bucket_name]
+  kms_key_refs = local.instance_profile_kms_key_access_ids
+  s3_buckets_write = local.instance_profile_writable_buckets
 }

--- a/groups/fil/kms.tf
+++ b/groups/fil/kms.tf
@@ -12,6 +12,8 @@ resource "aws_kms_key" "fil" {
 }
 
 resource "aws_kms_alias" "fil" {
+  count = var.ef_presenter_data_bucket_enabled ? 1 : 0
+
   name          = "alias/${local.common_resource_name}"
   target_key_id = aws_kms_key.fil[0].key_id
 }

--- a/groups/fil/kms.tf
+++ b/groups/fil/kms.tf
@@ -1,6 +1,6 @@
 
 resource "aws_kms_key" "fil" {
-  count = var.create_ef_presenter_data_bucket ? 1 : 0
+  count = var.ef_presenter_data_bucket_enabled ? 1 : 0
 
   description         = "KMS key for FIL Tuxedo services"
   enable_key_rotation = true

--- a/groups/fil/kms.tf
+++ b/groups/fil/kms.tf
@@ -4,7 +4,7 @@ resource "aws_kms_key" "fil" {
 
   description         = "KMS key for FIL Tuxedo services"
   enable_key_rotation = true
-  policy              = data.aws_iam_policy_document.fil.json
+  policy              = data.aws_iam_policy_document.fil[0].json
 
   tags = merge(local.common_tags, {
     Name = local.common_resource_name

--- a/groups/fil/kms.tf
+++ b/groups/fil/kms.tf
@@ -1,0 +1,17 @@
+
+resource "aws_kms_key" "fil" {
+  count = var.create_ef_presenter_data_bucket ? 1 : 0
+
+  description         = "KMS key for FIL Tuxedo services"
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.fil.json
+
+  tags = merge(local.common_tags, {
+    Name = local.common_resource_name
+  })
+}
+
+resource "aws_kms_alias" "fil" {
+  name          = "alias/${local.common_resource_name}"
+  target_key_id = aws_kms_key.fil[0].key_id
+}

--- a/groups/fil/locals.tf
+++ b/groups/fil/locals.tf
@@ -40,14 +40,14 @@ locals {
 
   instance_profile_writable_buckets = flatten([
     local.session_manager_bucket_name,
-    var.create_ef_presenter_data_bucket ? [local.ef_presenter_data_bucket_name] : []
+    var.ef_presenter_data_bucket_enabled ? [local.ef_presenter_data_bucket_name] : []
   ])
 
   instance_profile_kms_key_access_ids = flatten([
     local.ssm_kms_key_id,
-    var.create_ef_presenter_data_bucket ? [aws_kms_key.fil[0].key_id] : []
+    var.ef_presenter_data_bucket_enabled ? [aws_kms_key.fil[0].key_id] : []
   ])
 
-  logs_kms_key_id = data.vault_generic_secret.kms_keys.data["logs"]
+  logs_kms_key_id            = data.vault_generic_secret.kms_keys.data["logs"]
   kms_key_administrator_arns = concat(tolist(data.aws_iam_roles.sso_administrator.arns), [data.aws_iam_user.concourse.arn])
 }

--- a/groups/fil/locals.tf
+++ b/groups/fil/locals.tf
@@ -36,5 +36,18 @@ locals {
     }
   ]...)
 
+  ef_presenter_data_bucket_name = "ef-presenter-data.${var.service_subtype}.${var.service}.${var.aws_account}.ch.gov.uk"
+
+  instance_profile_writable_buckets = flatten([
+    local.session_manager_bucket_name,
+    var.create_ef_presenter_data_bucket ? [local.ef_presenter_data_bucket_name] : []
+  ])
+
+  instance_profile_kms_key_access_ids = flatten([
+    local.ssm_kms_key_id,
+    var.create_ef_presenter_data_bucket ? [aws_kms_key.fil[0].key_id] : []
+  ])
+
   logs_kms_key_id = data.vault_generic_secret.kms_keys.data["logs"]
+  kms_key_administrator_arns = concat(tolist(data.aws_iam_roles.sso_administrator.arns), [data.aws_iam_user.concourse.arn])
 }

--- a/groups/fil/main.tf
+++ b/groups/fil/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = var.region
-  version = "~> 2.65.0"
+  version = ">= 3.0.0, < 4.0.0"
 }
 
 terraform {

--- a/groups/fil/profiles/heritage-staging-eu-west-2/staging/vars
+++ b/groups/fil/profiles/heritage-staging-eu-west-2/staging/vars
@@ -7,3 +7,5 @@ instance_count = 2
 instance_type = "m5.large"
 
 root_volume_size = 100
+
+ef_presenter_data_bucket_enabled = true

--- a/groups/fil/s3.tf
+++ b/groups/fil/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "ef_presenter_data" {
-  count = var.create_ef_presenter_data_bucket ? 1 : 0
+  count = var.ef_presenter_data_bucket_enabled ? 1 : 0
 
   bucket = local.ef_presenter_data_bucket_name
 
@@ -16,7 +16,7 @@ resource "aws_s3_bucket" "ef_presenter_data" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "ef_presenter_data" {
-  count = var.create_ef_presenter_data_bucket ? 1 : 0
+  count = var.ef_presenter_data_bucket_enabled ? 1 : 0
 
   bucket = aws_s3_bucket.ef_presenter_data[0].id
 
@@ -29,14 +29,14 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "ef_presenter_data
 }
 
 resource "aws_s3_bucket_policy" "ef_presenter_data" {
-  count = var.create_ef_presenter_data_bucket ? 1 : 0
+  count = var.ef_presenter_data_bucket_enabled ? 1 : 0
 
   bucket = aws_s3_bucket.ef_presenter_data[0].id
   policy = data.aws_iam_policy_document.ef_presenter_data_bucket.json
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "ef_presenter_data" {
-  count = var.create_ef_presenter_data_bucket ? 1 : 0
+  count = var.ef_presenter_data_bucket_enabled ? 1 : 0
 
   bucket = aws_s3_bucket.ef_presenter_data[0].id
 
@@ -54,7 +54,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "ef_presenter_data" {
 }
 
 resource "aws_s3_bucket_public_access_block" "ef_presenter_data" {
-  count = var.create_ef_presenter_data_bucket ? 1 : 0
+  count = var.ef_presenter_data_bucket_enabled ? 1 : 0
 
   bucket = aws_s3_bucket.ef_presenter_data[0].id
 

--- a/groups/fil/s3.tf
+++ b/groups/fil/s3.tf
@@ -32,7 +32,7 @@ resource "aws_s3_bucket_policy" "ef_presenter_data" {
   count = var.ef_presenter_data_bucket_enabled ? 1 : 0
 
   bucket = aws_s3_bucket.ef_presenter_data[0].id
-  policy = data.aws_iam_policy_document.ef_presenter_data_bucket.json
+  policy = data.aws_iam_policy_document.ef_presenter_data_bucket[0].json
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "ef_presenter_data" {

--- a/groups/fil/s3.tf
+++ b/groups/fil/s3.tf
@@ -1,0 +1,65 @@
+resource "aws_s3_bucket" "ef_presenter_data" {
+  count = var.create_ef_presenter_data_bucket ? 1 : 0
+
+  bucket = local.ef_presenter_data_bucket_name
+
+  # TODO Remove lifecycle block after migration to version 4.x of the Terraform
+  # AWS provider; this currently stops plan/apply operations from flip-flopping
+  # between adding/removing configuration; see the GitHub issue link for context:
+  # https://github.com/hashicorp/terraform-provider-aws/issues/23758
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule,
+      server_side_encryption_configuration
+    ]
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "ef_presenter_data" {
+  count = var.create_ef_presenter_data_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.ef_presenter_data[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.fil[0].arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "ef_presenter_data" {
+  count = var.create_ef_presenter_data_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.ef_presenter_data[0].id
+  policy = data.aws_iam_policy_document.ef_presenter_data_bucket.json
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "ef_presenter_data" {
+  count = var.create_ef_presenter_data_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.ef_presenter_data[0].id
+
+  rule {
+    id = "ef-presenter-data-expiration"
+
+    filter {}
+
+    expiration {
+      days = 14
+    }
+
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "ef_presenter_data" {
+  count = var.create_ef_presenter_data_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.ef_presenter_data[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/groups/fil/variables.tf
+++ b/groups/fil/variables.tf
@@ -25,6 +25,12 @@ variable "chips_cidr" {
   description = "A string representing the CIDR range from which CHIPS instances will connect to Tuxedo services"
 }
 
+variable "create_ef_presenter_data_bucket" {
+  type        = bool
+  description = "A boolean value representing whether to create an S3 bucket and associated resources for EF presenter data"
+  default     = false
+}
+
 variable "default_log_retention_in_days" {
   type        = string
   description = "The default log retention period in days for CloudWatch log groups"
@@ -45,6 +51,12 @@ variable "dns_zone_suffix" {
 variable "environment" {
   type        = string
   description = "The environment name to be used when creating AWS resources"
+}
+
+variable "ef_presenter_data_read_only_principal_arns" {
+  type        = list(string)
+  description = "An optional list of principal ARNs which will be granted read-only access to the EF preseter data bucket and decryption key, applicable only when 'create_ef_presenter_data_bucket' is true"
+  default     = []
 }
 
 variable "instance_count" {

--- a/groups/fil/variables.tf
+++ b/groups/fil/variables.tf
@@ -25,12 +25,6 @@ variable "chips_cidr" {
   description = "A string representing the CIDR range from which CHIPS instances will connect to Tuxedo services"
 }
 
-variable "create_ef_presenter_data_bucket" {
-  type        = bool
-  description = "A boolean value representing whether to create an S3 bucket and associated resources for EF presenter data"
-  default     = false
-}
-
 variable "default_log_retention_in_days" {
   type        = string
   description = "The default log retention period in days for CloudWatch log groups"
@@ -53,9 +47,15 @@ variable "environment" {
   description = "The environment name to be used when creating AWS resources"
 }
 
-variable "ef_presenter_data_read_only_principal_arns" {
+variable "ef_presenter_data_bucket_enabled" {
+  type        = bool
+  description = "A boolean value representing whether to create an S3 bucket and associated resources for EF presenter data"
+  default     = false
+}
+
+variable "ef_presenter_data_read_only_principals" {
   type        = list(string)
-  description = "An optional list of principal ARNs which will be granted read-only access to the EF preseter data bucket and decryption key, applicable only when 'create_ef_presenter_data_bucket' is true"
+  description = "An optional list of principal ARNs which will be granted read-only access to the EF preseter data bucket and use of the decryption key, applicable only when 'ef_presenter_data_bucket_enabled' is true"
   default     = []
 }
 


### PR DESCRIPTION
These changes introduce support for transferring presenter data to an S3 bucket for retrieval and processing by XML backend instances and includes:

* Added KMS key and S3 bucket with default server-side encryption for presenter data transfer to XML backend instances
* Added variable `ef_presenter_data_bucket_enabled` to control creation of S3 bucket and associated resources on a per-environment basis
* Added variable `ef_presenter_data_read_only_principals` to provide other principals (e.g. XML backend instance role) read-only access to the S3 bucket and the ability to decrypt objects using the KMS key 
* Migrated to AWS provider version `>= 3.0.0, < 4.0.0` and documented a known issue with `aws_s3_bucket` resource pending an update to provider version `4.0.0+`

Resolves: `DVOP-2100`.
