### PR TITLE
Fix for missing wildcard suffix due to provider update

### DIFF
--- a/groups/fil/iam.tf
+++ b/groups/fil/iam.tf
@@ -2,7 +2,7 @@ module "instance_profile" {
   source = "git@github.com:companieshouse/terraform-modules//aws/instance_profile?ref=tags/1.0.62"
   name   = "${var.service_subtype}-${var.service}-profile"
 
-  cw_log_group_arns = [for log_group in merge(aws_cloudwatch_log_group.tuxedo, { "cloudwatch" = aws_cloudwatch_log_group.cloudwatch }) : log_group.arn]
+  cw_log_group_arns = formatlist("%s:*", local.tuxedo_log_group_arns)
   enable_SSM        = true
   kms_key_refs      = local.instance_profile_kms_key_access_ids
   s3_buckets_write  = local.instance_profile_writable_buckets

--- a/groups/fil/locals.tf
+++ b/groups/fil/locals.tf
@@ -36,6 +36,14 @@ locals {
     }
   ]...)
 
+  tuxedo_log_group_arns = [
+    for log_group in merge(
+      aws_cloudwatch_log_group.tuxedo,
+      { "cloudwatch" = aws_cloudwatch_log_group.cloudwatch }
+    )
+    : log_group.arn
+  ]
+
   ef_presenter_data_bucket_name = "ef-presenter-data.${var.service_subtype}.${var.service}.${var.aws_account}.ch.gov.uk"
 
   instance_profile_writable_buckets = flatten([


### PR DESCRIPTION
These changes address a breaking change caused by a provider update in #47: the `arn` attribute of `aws_cloudwatch_log_group` resources no longer includes the wildcard suffix (`:*`) for log streams with Terraform AWS provider versions >= `3.0.0`, meaning the IAM policy created by the  `instance_profile` module is not enforced as `logs:PutLogEvents` actions must be applied to log stream resources rather than log groups.