### PR TITLE
Add write policy action for CloudWatch metrics

### DIFF
--- a/groups/fil/iam.tf
+++ b/groups/fil/iam.tf
@@ -6,4 +6,15 @@ module "instance_profile" {
   enable_SSM        = true
   kms_key_refs      = local.instance_profile_kms_key_access_ids
   s3_buckets_write  = local.instance_profile_writable_buckets
+
+  custom_statements = [
+    {
+      sid       = "CloudWatchMetricsWrite"
+      effect    = "Allow"
+      resources = ["*"]
+      actions = [
+        "cloudwatch:PutMetricData"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
These instance profile policy changes allow Tuxedo instances to write CloudWatch metrics for additional context when troubleshooting.

Resolves: `DVOP-2255`