### PR TITLE
Switch to Postfix mail transfer agent

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -26,7 +26,21 @@ cloudwatch_agent_defaults:
 getent_gid_index: 2
 getent_uid_index: 1
 
-smtp_mail_relay: smtp-outbound.sharedservices.aws.internal
+postfix_main_config_file: /etc/postfix/main.cf
+
+postfix_config:
+  - key: mydomain
+    value: companieshouse.gov.uk
+  - key: myorigin
+    value: $mydomain
+  - key: relayhost
+    value: smtp-outbound.sharedservices.aws.internal
+
+postfix_net_config:
+  - key: inet_interfaces
+    value: all
+  - key: inet_protocols
+    value: ipv4
 
 tuxedo_log_files:
   cabs:

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -8,3 +8,9 @@
   loop:
     - cups
     - colord
+
+- name: Restart Postfix service
+  systemd:
+    name: postfix
+    state: restarted
+    enabled: yes

--- a/roles/deploy/tasks/tools.yml
+++ b/roles/deploy/tasks/tools.yml
@@ -11,17 +11,35 @@
   notify:
     - Start printer support services
 
-- name: Flush handlers
-  meta: flush_handlers
-
 - name: Configure SMS printer
   shell: "lpadmin -p {{ sms_printer_name }} -E -v {{ sms_printer_uri }} -m {{ sms_printer_model }} && touch /etc/fil-tuxedo-stack-deploy-provisioned-sms-printer"
   args:
     creates: /etc/fil-tuxedo-stack-deploy-provisioned-sms-printer
 
-- name: Configure mailx SMTP relay
-  lineinfile:
+- name: Disable mailx inbuilt SMTP relay
+  replace:
     path: /etc/mail.rc
-    regexp: '^set smtp='
-    line: 'set smtp={{ smtp_mail_relay }}'
+    regexp: '^(set smtp=.*)'
+    replace: '#\1'
 
+- name: Update Postfix configuration for mail relay (existing commented lines)
+  lineinfile:
+    dest: "{{ postfix_main_config_file }}"
+    line: "{{ item.key }} = {{ item.value }}"
+    regexp: "^#{{ item.key }} ="
+    insertafter: "^#{{ item.key }} ="
+  loop: "{{ postfix_config }}"
+  notify:
+    - Restart Postfix service
+
+- name: Update Postfix network config (existing uncommented lines)
+  lineinfile:
+    dest: "{{ postfix_main_config_file }}"
+    line: "{{ item.key }} = {{ item.value }}"
+    regexp: "^{{ item.key }} ="
+  loop: "{{ postfix_net_config }}"
+  notify:
+    - Restart Postfix service
+
+- name: Flush handlers
+  meta: flush_handlers


### PR DESCRIPTION
These changes replace the previously used SMTP functionality of `mailx` with the Postfix mail transfer agent and suitable configuration.