### PR TITLE
Migrate infrastructure code to Terraform 1.3

### DIFF
--- a/groups/fil/iam.tf
+++ b/groups/fil/iam.tf
@@ -1,9 +1,9 @@
 module "instance_profile" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/instance_profile?ref=tags/1.0.62"
+  source = "git@github.com:companieshouse/terraform-modules//aws/instance_profile?ref=tags/1.0.211"
   name   = "${var.service_subtype}-${var.service}-profile"
 
   cw_log_group_arns = formatlist("%s:*", local.tuxedo_log_group_arns)
-  enable_SSM        = true
+  enable_ssm        = true
   kms_key_refs      = local.instance_profile_kms_key_access_ids
   s3_buckets_write  = local.instance_profile_writable_buckets
 

--- a/groups/fil/instance.tf
+++ b/groups/fil/instance.tf
@@ -5,8 +5,11 @@ data "aws_vpc" "heritage" {
   }
 }
 
-data "aws_subnet_ids" "application" {
-  vpc_id = data.aws_vpc.heritage.id
+data "aws_subnets" "application" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.heritage.id]
+  }
 
   filter {
     name   = "tag:Name"
@@ -15,8 +18,8 @@ data "aws_subnet_ids" "application" {
 }
 
 data "aws_subnet" "application" {
-  count = length(data.aws_subnet_ids.application.ids)
-  id    = tolist(data.aws_subnet_ids.application.ids)[count.index]
+  count = length(data.aws_subnets.application.ids)
+  id    = tolist(data.aws_subnets.application.ids)[count.index]
 }
 
 data "aws_ami" "fil_tuxedo" {

--- a/groups/fil/main.tf
+++ b/groups/fil/main.tf
@@ -1,9 +1,16 @@
-provider "aws" {
-  region  = var.region
-  version = ">= 3.0.0, < 4.0.0"
+terraform {
+  required_version = ">= 1.3, < 1.4"
+
+  backend "s3" {}
+
+  required_providers {
+    aws = {
+      version = ">= 5.0, < 6.0"
+      source = "hashicorp/aws"
+    }
+  }
 }
 
-terraform {
-  backend "s3" {
-  }
+provider "aws" {
+  region  = var.region
 }

--- a/groups/fil/s3.tf
+++ b/groups/fil/s3.tf
@@ -2,17 +2,6 @@ resource "aws_s3_bucket" "ef_presenter_data" {
   count = var.ef_presenter_data_bucket_enabled ? 1 : 0
 
   bucket = local.ef_presenter_data_bucket_name
-
-  # TODO Remove lifecycle block after migration to version 4.x of the Terraform
-  # AWS provider; this currently stops plan/apply operations from flip-flopping
-  # between adding/removing configuration; see the GitHub issue link for context:
-  # https://github.com/hashicorp/terraform-provider-aws/issues/23758
-  lifecycle {
-    ignore_changes = [
-      lifecycle_rule,
-      server_side_encryption_configuration
-    ]
-  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "ef_presenter_data" {


### PR DESCRIPTION
These changes upgrade the codebase to work with Terraform version 1.3 and include the following modifications and improvements:

- Update Terraform version constraint
- Update `terraform-modules/aws/instance_profile` module version
- Update AWS provider version constraint
- Replace deprecated AWS provider data source `aws_subnet_ids` with `aws_subnets`
- Remove `lifecycle` block workaround for AWS provider versions `< 4.0` (see https://github.com/hashicorp/terraform-provider-aws/issues/23758#issuecomment-1077748803)

Related: https://github.com/companieshouse/ci-pipelines/pull/2653.