### PR TITLE
Use canonical YAML truthy values

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,9 +1,9 @@
 [defaults]
-host_key_checking = False
+host_key_checking = false
 timeout = 60
 
 [inventory]
 enable_plugins = aws_ec2
 
 [ssh_connection]
-pipelining = True
+pipelining = true

--- a/database.yml
+++ b/database.yml
@@ -12,7 +12,7 @@
 - hosts: aws_ec2
   serial: 1
   remote_user: centos
-  become: yes
+  become: true
   roles:
     - role: informix-db
       vars:

--- a/deploy.yml
+++ b/deploy.yml
@@ -12,7 +12,7 @@
 - hosts: aws_ec2
   serial: 1
   remote_user: centos
-  become: yes
+  become: true
   roles:
     - role: aws-cli
       vars:

--- a/devices.yml
+++ b/devices.yml
@@ -12,7 +12,7 @@
 - hosts: aws_ec2
   serial: 1
   remote_user: centos
-  become: yes
+  become: true
   roles:
     - role: iscsi-devices
       vars:

--- a/group_vars/tag_Environment_development.yml
+++ b/group_vars/tag_Environment_development.yml
@@ -12,12 +12,12 @@
 #   - prod 1 (primary/secondary)
 #   - scud 2 (primary/secondary)
 
-informix_management_alerts_enabled: no
-informix_management_stats_enabled: no
+informix_management_alerts_enabled: false
+informix_management_stats_enabled: false
 
 iscsi_devices_config:
   - alias: db_dump
-    multipath: no
+    multipath: false
     filesystem:
       type: xfs
       path: /db_dump
@@ -25,19 +25,19 @@ iscsi_devices_config:
       owner: informix
       group: informix
   - alias: scud
-    multipath: no
+    multipath: false
     raw_character_device:
       path: /dev/raw/raw1
       owner: informix
       group: informix
   - alias: prod
-    multipath: no
+    multipath: false
     raw_character_device:
       path: /dev/raw/raw2
       owner: informix
       group: informix
   - alias: ef
-    multipath: no
+    multipath: false
     raw_character_device:
       path: /dev/raw/raw3
       owner: informix

--- a/group_vars/tag_Environment_live.yml
+++ b/group_vars/tag_Environment_live.yml
@@ -12,14 +12,14 @@
 #   - prod 1 (primary/secondary)
 #   - scud 2 (primary/secondary)
 
-informix_management_alerts_enabled: yes
+informix_management_alerts_enabled: true
 informix_management_alerts_vault_path: "{{ vault_base_path }}/alerts"
-informix_management_stats_enabled: yes
+informix_management_stats_enabled: true
 informix_management_stats_vault_path:  "{{ vault_base_path }}/stats"
 
 iscsi_devices_config:
   - alias: db_dump
-    multipath: yes
+    multipath: true
     filesystem:
       type: xfs
       path: /db_dump
@@ -27,19 +27,19 @@ iscsi_devices_config:
       owner: informix
       group: informix
   - alias: scud
-    multipath: yes
+    multipath: true
     raw_character_device:
       path: /dev/raw/raw1
       owner: informix
       group: informix
   - alias: prod
-    multipath: yes
+    multipath: true
     raw_character_device:
       path: /dev/raw/raw2
       owner: informix
       group: informix
   - alias: ef
-    multipath: yes
+    multipath: true
     raw_character_device:
       path: /dev/raw/raw3
       owner: informix
@@ -53,15 +53,15 @@ informix_server_port_increment: 1000
 informix_server_port_start: 6000
 
 alerts:
-  enabled: yes
+  enabled: true
   vault_path: "{{ vault_base_path }}/alerts"
 
 stats:
-  enabled: yes
+  enabled: true
   vault_path: "{{ vault_base_path }}/stats"
 
 ef_presenter_data:
-  enabled: yes
+  enabled: true
   vault_path: "{{ vault_base_path }}/ef-presenter"
 
 cloudwatch_agent_overrides:

--- a/group_vars/tag_Environment_staging.yml
+++ b/group_vars/tag_Environment_staging.yml
@@ -12,14 +12,14 @@
 #   - prod 1 (primary/secondary)
 #   - scud 2 (primary/secondary)
 
-informix_management_alerts_enabled: yes
+informix_management_alerts_enabled: true
 informix_management_alerts_vault_path: "{{ vault_base_path }}/alerts"
-informix_management_stats_enabled: yes
+informix_management_stats_enabled: true
 informix_management_stats_vault_path:  "{{ vault_base_path }}/stats"
 
 iscsi_devices_config:
   - alias: db_dump
-    multipath: yes
+    multipath: true
     filesystem:
       type: xfs
       path: /db_dump
@@ -27,19 +27,19 @@ iscsi_devices_config:
       owner: informix
       group: informix
   - alias: scud
-    multipath: yes
+    multipath: true
     raw_character_device:
       path: /dev/raw/raw1
       owner: informix
       group: informix
   - alias: prod
-    multipath: yes
+    multipath: true
     raw_character_device:
       path: /dev/raw/raw2
       owner: informix
       group: informix
   - alias: ef
-    multipath: yes
+    multipath: true
     raw_character_device:
       path: /dev/raw/raw3
       owner: informix
@@ -51,7 +51,7 @@ informix_server_port_increment: 1000
 informix_server_port_start: 6000
 
 ef_presenter_data:
-  enabled: yes
+  enabled: true
   vault_path: "{{ vault_base_path }}/ef-presenter"
 
 cloudwatch_agent_overrides:

--- a/management.yml
+++ b/management.yml
@@ -12,6 +12,6 @@
 - hosts: aws_ec2
   serial: 1
   remote_user: centos
-  become: yes
+  become: true
   roles:
     - informix-management

--- a/nfs.yml
+++ b/nfs.yml
@@ -12,6 +12,6 @@
 - hosts: aws_ec2
   serial: 1
   remote_user: centos
-  become: yes
+  become: true
   roles:
     - role: nfs-mounts

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -1,13 +1,13 @@
 ---
 
 alerts:
-  enabled: no
+  enabled: false
 
 stats:
-  enabled: no
+  enabled: false
 
 ef_presenter_data:
-  enabled: no
+  enabled: false
 
 sms_poll_daemon_enabled: false
 

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -4,7 +4,7 @@
   systemd:
     name: "{{ item }}"
     state: started
-    enabled: yes
+    enabled: true
   loop:
     - cups
     - colord
@@ -13,4 +13,4 @@
   systemd:
     name: postfix
     state: restarted
-    enabled: yes
+    enabled: true

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -13,7 +13,7 @@
   systemd:
     name: "{{ item }}"
     state: stopped
-    enabled: no
+    enabled: false
   loop:
     - cups
     - colord

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -16,7 +16,7 @@
     tuxedo_logical_machine_id: "{{ tuxedo_user | upper }}_{{ tuxedo_logical_machine_id_suffix }}"
     tuxedo_machine_name: "{{ ansible_facts.hostname }}"
     tuxedo_user_id: "{{ getent_passwd[tuxedo_user][getent_uid_index] }}"
-  no_log: True
+  no_log: true
 
 - name: Retrieve alerts config from Hashicorp Vault
   set_fact:
@@ -82,7 +82,7 @@
     mode: 0644
   with_fileglob:
     - "{{ application_configs_path }}/{{ tuxedo_user }}/*.j2"
-  no_log: True
+  no_log: true
 
 - name: "{{ tuxedo_user }} : Create scripts directory"
   file:
@@ -205,7 +205,7 @@
   template:
     src: templates/cloudwatch-config-service.json.j2
     dest: "{{ cloudwatch_agent.config_dir }}/cloudwatch-config-{{ tuxedo_user }}.json"
-    trim_blocks: False
+    trim_blocks: false
 
 - name: "{{ tuxedo_user }} : Start Tuxedo services"
   become_user: "{{ tuxedo_user }}"
@@ -229,7 +229,7 @@
     group: "{{ tuxedo_user }}"
     mode: 0400
   when: stats.enabled
-  no_log: True
+  no_log: true
 
 - name: "{{ tuxedo_user }} : Create maintenance jobs"
   cron:

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -107,7 +107,7 @@
     path: "{{ new_deployment_files.path }}"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    recurse: yes
+    recurse: true
 
 - name: "{{ tuxedo_user }} : Check state of {{ tuxedo_user }} current deployment directory"
   stat:
@@ -119,7 +119,7 @@
   shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/sms_poll_stop"
   args:
     executable: /bin/bash
-  ignore_errors: yes
+  ignore_errors: true
   when: sms_poll_daemon_enabled and tuxedo_user == "scud"
 
 - name: "{{ tuxedo_user }} : Stop Tuxedo services"
@@ -127,7 +127,7 @@
   shell: "source {{ tuxedo_env_file_path }} && timeout -s 9 20 tmshutdown -y"
   args:
     executable: /bin/bash
-  ignore_errors: yes
+  ignore_errors: true
   when: current_deployment_files.stat.exists
 
 - name: "{{ tuxedo_user }} : Clear IPC facilities"
@@ -218,7 +218,7 @@
   shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/sms_poll_start"
   args:
     executable: /bin/bash
-  ignore_errors: yes
+  ignore_errors: true
   when: sms_poll_daemon_enabled and tuxedo_user == "scud"
 
 - name: Create autologin configuration for FTP client

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -64,7 +64,7 @@
   unarchive:
     src: "{{ application_artifact_path }}"
     dest: "{{ application_artifact_files.path }}"
-    remote_src: no
+    remote_src: false
     owner: root
     group: "{{ tuxedo_service_group }}"
     mode: 0755

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -35,7 +35,7 @@
   template:
     src: templates/cloudwatch-config.json.j2
     dest: "{{ cloudwatch_agent.config_dir }}/cloudwatch-config.json"
-    trim_blocks: False
+    trim_blocks: false
 
 - name: Start CloudWatch agent using primary configuration file
   command:

--- a/roles/deploy/tasks/tools.yml
+++ b/roles/deploy/tasks/tools.yml
@@ -20,7 +20,7 @@
 - name: Check printer configuration exists
   shell: "lpstat -p {{ sms_printer_name }}"
   register: sms_printer_exists
-  ignore_errors: yes
+  ignore_errors: true
 
 - name: Add SMS printer configuration
   shell: "lpadmin -p {{ sms_printer_name }} -E -v {{ sms_printer_uri }} -m {{ sms_printer_model }}"


### PR DESCRIPTION
These changes ensure that truthy values are represented using canonical [YAML boolean form](https://yaml.org/spec/1.2.1/#id2803629) in accordance with recent [Ansible documentation updates](https://github.com/ansible/ansible/pull/78429) and will suppress `yamllint` warnings.