### PR TITLE
Bump ansible-role-nfs-mounts version

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -15,7 +15,7 @@ roles:
     version: "1.1.3"
   - src: https://github.com/companieshouse/ansible-role-nfs-mounts
     name: nfs-mounts
-    version: "1.0.0"
+    version: "1.1.0"
   - src: https://github.com/companieshouse/ansible-role-ssh-key
     name: ssh-key
     version: "1.0.0"


### PR DESCRIPTION
This change ensures that we inherit the default `nfsvers=4` option for `fstab` NFS mount entries ensuring use of version 4 of the NFS protocol. 