### PR TITLE
Refactoring improvements for deploy role

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,4 @@
+---
+# .ansible-lint
+
+profile: production

--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,1 @@
+roles/deploy/defaults/main.yml var-naming[no-role-prefix]

--- a/database.yml
+++ b/database.yml
@@ -1,15 +1,15 @@
 ---
 
-# Provision Ansible controller with SSH key for remote
-- hosts: localhost
+- name: Provision Ansible controller with SSH key for remote
+  hosts: localhost
   roles:
     - role: ssh-key
       vars:
         ssh_key_name: ansible_remote
         hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
 
-# Provision Informix dbspaces and chunks
-- hosts: aws_ec2
+- name: Provision Informix dbspaces and chunks
+  hosts: aws_ec2
   serial: 1
   remote_user: centos
   become: true

--- a/database.yml
+++ b/database.yml
@@ -3,10 +3,10 @@
 - name: Provision Ansible controller with SSH key for remote
   hosts: localhost
   roles:
-    - role: ssh-key
+    - role: companieshouse.general.ssh_key
       vars:
         ssh_key_name: ansible_remote
-        hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
+        ssh_key_vault_path: "{{ vault_base_path }}/aws"
 
 - name: Provision Informix dbspaces and chunks
   hosts: aws_ec2

--- a/deploy.yml
+++ b/deploy.yml
@@ -1,15 +1,15 @@
 ---
 
-# Provision Ansible controller with SSH key for remote
-- hosts: localhost
+- name: Provision Ansible controller with SSH key for remote
+  hosts: localhost
   roles:
     - role: ssh-key
       vars:
         ssh_key_name: ansible_remote
         hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
 
-# Deploy Tuxedo services
-- hosts: aws_ec2
+- name: Deploy Tuxedo services
+  hosts: aws_ec2
   serial: 1
   remote_user: centos
   become: true

--- a/deploy.yml
+++ b/deploy.yml
@@ -3,10 +3,10 @@
 - name: Provision Ansible controller with SSH key for remote
   hosts: localhost
   roles:
-    - role: ssh-key
+    - role: companieshouse.general.ssh_key
       vars:
         ssh_key_name: ansible_remote
-        hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
+        ssh_key_vault_path: "{{ vault_base_path }}/aws"
 
 - name: Deploy Tuxedo services
   hosts: aws_ec2
@@ -14,8 +14,8 @@
   remote_user: centos
   become: true
   roles:
-    - role: systemd-journald
-    - role: aws-cli
+    - role: companieshouse.general.systemd_journald
+    - role: companieshouse.general.aws_cli
       vars:
         aws_cli_temp_dir: "/home/{{ ansible_user }}"
     - role: deploy

--- a/devices.yml
+++ b/devices.yml
@@ -1,15 +1,15 @@
 ---
 
-# Provision Ansible controller with SSH key for remote
-- hosts: localhost
+- name: Provision Ansible controller with SSH key for remote
+  hosts: localhost
   roles:
     - role: ssh-key
       vars:
         ssh_key_name: ansible_remote
         hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
 
-# Provision iSCSI devices
-- hosts: aws_ec2
+- name: Provision iSCSI devices
+  hosts: aws_ec2
   serial: 1
   remote_user: centos
   become: true

--- a/devices.yml
+++ b/devices.yml
@@ -3,10 +3,10 @@
 - name: Provision Ansible controller with SSH key for remote
   hosts: localhost
   roles:
-    - role: ssh-key
+    - role: companieshouse.general.ssh_key
       vars:
         ssh_key_name: ansible_remote
-        hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
+        ssh_key_vault_path: "{{ vault_base_path }}/aws"
 
 - name: Provision iSCSI devices
   hosts: aws_ec2

--- a/management.yml
+++ b/management.yml
@@ -1,15 +1,15 @@
 ---
 
-# Provision Ansible controller with SSH key for remote
-- hosts: localhost
+- name: Provision Ansible controller with SSH key for remote
+  hosts: localhost
   roles:
     - role: ssh-key
       vars:
         ssh_key_name: ansible_remote
         hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
 
-# Provision Informix management scripts and cron jobs
-- hosts: aws_ec2
+- name: Provision Informix management scripts and cron jobs
+  hosts: aws_ec2
   serial: 1
   remote_user: centos
   become: true

--- a/management.yml
+++ b/management.yml
@@ -3,10 +3,10 @@
 - name: Provision Ansible controller with SSH key for remote
   hosts: localhost
   roles:
-    - role: ssh-key
+    - role: companieshouse.general.ssh_key
       vars:
         ssh_key_name: ansible_remote
-        hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
+        ssh_key_vault_path: "{{ vault_base_path }}/aws"
 
 - name: Provision Informix management scripts and cron jobs
   hosts: aws_ec2

--- a/nfs.yml
+++ b/nfs.yml
@@ -1,15 +1,15 @@
 ---
 
-# Provision Ansible controller with SSH key for remote
-- hosts: localhost
+- name: Provision Ansible controller with SSH key for remote
+  hosts: localhost
   roles:
     - role: ssh-key
       vars:
         ssh_key_name: ansible_remote
         hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
 
-# Provision NFS mounts
-- hosts: aws_ec2
+- name: Provision NFS mounts
+  hosts: aws_ec2
   serial: 1
   remote_user: centos
   become: true

--- a/nfs.yml
+++ b/nfs.yml
@@ -3,10 +3,10 @@
 - name: Provision Ansible controller with SSH key for remote
   hosts: localhost
   roles:
-    - role: ssh-key
+    - role: companieshouse.general.ssh_key
       vars:
         ssh_key_name: ansible_remote
-        hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
+        ssh_key_vault_path: "{{ vault_base_path }}/aws"
 
 - name: Provision NFS mounts
   hosts: aws_ec2

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,9 +1,6 @@
 ---
 
 roles:
-  - src: https://github.com/companieshouse/ansible-role-aws-cli
-    name: aws-cli
-    version: "1.0.1"
   - src: https://github.com/companieshouse/ansible-role-informix-db
     name: informix-db
     version: "1.0.6"
@@ -16,12 +13,6 @@ roles:
   - src: https://github.com/companieshouse/ansible-role-nfs-mounts
     name: nfs-mounts
     version: "1.1.0"
-  - src: https://github.com/companieshouse/ansible-role-ssh-key
-    name: ssh-key
-    version: "1.0.0"
-  - src: "https://github.com/companieshouse/ansible-role-systemd-journald"
-    name: systemd-journald
-    version: "1.0.0"
 
 collections:
   - name: amazon.aws
@@ -30,3 +21,5 @@ collections:
     version: "4.8.0"
   - name: community.hashi_vault
     version: "3.3.1"
+  - name: companieshouse.general
+    version: "1.0.1"

--- a/roles/deploy/README.md
+++ b/roles/deploy/README.md
@@ -52,12 +52,13 @@ ansible-playbook -i inventory --extra-vars='{"tuxedo_service_users": ["cabs"]}'
 
 The following variables are used by the `SMS` service and `SMS_poll` daemon that are deployed for the `scud` user:
 
-| Name                      | Default | Description                                                                           |
-|---------------------------|---------|---------------------------------------------------------------------------------------|
-| `sms_poll_daemon_enabled` | `false` | _Optional_. A boolean value indicating whether the `SMS_poll` daemon should be stopped before deployment and started again after deployment. |
-| `sms_printer_name`        | `sms-printer` | The name of the printer to be used by the `SMS` service. A corresponding `SMS_PRINTER` environment variable should be set to the same value in the environment file for `scud` user services (see [fil-tuxedo-configs](https://github.com/companieshouse/fil-tuxedo-configs)). |
-| `sms_printer_uri`         | `socket://172.19.12.18` | The URI of the printer to be used by the `SMS` service.              |
-| `sms_printer_model`       | `drv:///sample.drv/generic.ppd` | A standard System V interface script or PPD file for the printer from the model directory or one of the driver interfaces. Use the `-m` option with the `lpinfo(8)` command to get a list of supported models. |
+| Name                         | Default    | Description                                                                           |
+|------------------------------|------------|---------------------------------------------------------------------------------------|
+| `sms_poll_daemon_enabled`    | `false`    | _Optional_. A boolean value indicating whether the `SMS_poll` daemon should be stopped before deployment and started again after deployment. |
+| `sms_poll_daemon_executable` | `SMS_poll` | _Optional_. The executable name of the SMS poll daemon process.                       |
+| `sms_printer_name`           | `sms-printer` | The name of the printer to be used by the `SMS` service. A corresponding `SMS_PRINTER` environment variable should be set to the same value in the environment file for `scud` user services (see [fil-tuxedo-configs](https://github.com/companieshouse/fil-tuxedo-configs)). |
+| `sms_printer_uri`            | `socket://172.19.12.18` | The URI of the printer to be used by the `SMS` service.                  |
+| `sms_printer_model`          | `drv:///sample.drv/generic.ppd` | A standard System V interface script or PPD file for the printer from the model directory or one of the driver interfaces. Use the `-m` option with the `lpinfo(8)` command to get a list of supported models. |
 
 ### Logging
 

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -10,6 +10,7 @@ ef_presenter_data:
   enabled: false
 
 sms_poll_daemon_enabled: false
+sms_poll_daemon_executable: SMS_poll
 
 sms_printer_enabled: true
 sms_printer_name: sms-printer

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Start printer support services
-  systemd:
+  ansible.builtin.systemd:
     name: "{{ item }}"
     state: started
     enabled: true
@@ -10,7 +10,7 @@
     - colord
 
 - name: Stop printer support services
-  systemd:
+  ansible.builtin.systemd:
     name: "{{ item }}"
     state: stopped
     enabled: false
@@ -19,7 +19,7 @@
     - colord
 
 - name: Restart Postfix service
-  systemd:
+  ansible.builtin.systemd:
     name: postfix
     state: restarted
     enabled: true

--- a/roles/deploy/tasks/cron.yml
+++ b/roles/deploy/tasks/cron.yml
@@ -1,6 +1,7 @@
+---
 
 - name: Create system cron job for log rotation
-  cron:
+  ansible.builtin.cron:
     name: Log rotation for Tuxedo services
     weekday: "*"
     minute: "*/15"
@@ -10,7 +11,7 @@
     cron_file: /etc/cron.d/log-rotation
 
 - name: Create maintenance job for periodic mail spool truncation
-  cron:
+  ansible.builtin.cron:
     name: Periodic mail spool truncation
     special_time: weekly
     user: root
@@ -18,7 +19,7 @@
     cron_file: /etc/cron.d/mail-spool
 
 - name: Configure recipient addresses for system cron jobs
-  cronvar:
+  community.general.cronvar:
     name: MAILTO
     value: root@localhost
     cron_file: "{{ item }}"
@@ -30,7 +31,7 @@
     - /etc/cron.d/mail-spool
 
 - name: Configure recipient addresses for system anacron jobs
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/anacrontab
     regexp: '^MAILTO='
     line: MAILTO=root@localhost

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: "{{ tuxedo_user }} : Set additional variables for template population"
-  set_fact:
+- name: "Set additional variables for template population : {{ tuxedo_user }}"
+  ansible.builtin.set_fact:
     private_host_address: "{{ inventory_hostname }}"
     private_host_local_domain_port: "{{ tuxedo_service_config[tuxedo_user].local_domain_port }}"
     service_name: "{{ tuxedo_user }}"
@@ -18,23 +18,23 @@
     tuxedo_user_id: "{{ getent_passwd[tuxedo_user][getent_uid_index] }}"
   no_log: true
 
-- name: "{{ tuxedo_user }} : Retrieve alerts config from Hashicorp Vault"
-  set_fact:
+- name: "Retrieve alerts config from Hashicorp Vault : {{ tuxedo_user }}"
+  ansible.builtin.set_fact:
     alerts_config: "{{ lookup('community.hashi_vault.hashi_vault', alerts.vault_path) }}"
   when: alerts.enabled
 
-- name: "{{ tuxedo_user }} : Retrieve stats config from Hashicorp Vault"
-  set_fact:
+- name: "Retrieve stats config from Hashicorp Vault : {{ tuxedo_user }}"
+  ansible.builtin.set_fact:
     stats_config: "{{ lookup('community.hashi_vault.hashi_vault', stats.vault_path) }}"
   when: stats.enabled
 
-- name: "{{ tuxedo_user }} : Retrieve EF presenter data config from Hashicorp Vault"
-  set_fact:
+- name: "Retrieve EF presenter data config from Hashicorp Vault : {{ tuxedo_user }}"
+  ansible.builtin.set_fact:
     ef_presenter_config: "{{ lookup('community.hashi_vault.hashi_vault', ef_presenter_data.vault_path) }}"
   when: ef_presenter_data.enabled
 
-- name: "{{ tuxedo_user }} : Create additional data directories for {{ tuxedo_user }} services"
-  file:
+- name: "Create additional data directories for services : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "{{ item.path }}"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
@@ -42,197 +42,228 @@
     state: directory
   loop: "{{ data_directories[tuxedo_user] | default([]) }}"
 
-- name: "{{ tuxedo_user }} : Remove maintenance jobs during deploy"
-  file:
+- name: "Remove maintenance jobs during deploy : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "/var/spool/cron/{{ tuxedo_user }}"
     state: absent
 
-- name: "{{ tuxedo_user }} : Create temporary directory for new {{ tuxedo_user }} deployment"
+- name: "Create temporary directory for new deployment : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  tempfile:
+  ansible.builtin.tempfile:
     state: directory
   register: new_deployment_files
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Copy application artifact files to temporary {{ tuxedo_user }} deployment directory"
+- name: "Copy application artifact files to temporary deployment directory : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  command: "cp -r {{ application_artifact_files.path }}/. {{ new_deployment_files.path }}"
+  ansible.builtin.command: "cp -r {{ application_artifact_files.path }}/. {{ new_deployment_files.path }}"
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Create Tuxedo service logs directory"
-  file:
+- name: "Create Tuxedo service logs directory : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "{{ tuxedo_logs_path }}/{{ tuxedo_user }}"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    mode: 0755
+    mode: '0755'
     state: directory
 
-- name: "{{ tuxedo_user }} : Create config directory"
-  file:
+- name: "Create config directory : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "{{ new_deployment_files.path }}/config"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    mode: 0755
+    mode: '0755'
     state: directory
 
-- name: "{{ tuxedo_user }} : Populate Tuxedo template config files"
-  template:
+- name: "Populate Tuxedo template config files : {{ tuxedo_user }}"
+  ansible.builtin.template:
     src: "{{ item }}"
     dest: "{{ new_deployment_files.path }}/config/{{ item | basename | replace('.j2', '') }}"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    mode: 0644
+    mode: '0644'
   with_fileglob:
     - "{{ application_configs_path }}/{{ tuxedo_user }}/*.j2"
   no_log: true
 
-- name: "{{ tuxedo_user }} : Create scripts directory"
-  file:
+- name: "Create scripts directory : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "{{ new_deployment_files.path }}/scripts"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    mode: 0755
+    mode: '0755'
     state: directory
 
-- name: "{{ tuxedo_user }} : Populate script template files"
-  template:
+- name: "Populate script template files : {{ tuxedo_user }}"
+  ansible.builtin.template:
     src: "{{ item }}"
     dest: "{{ new_deployment_files.path }}/scripts/{{ item | basename | replace('.j2', '') }}"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    mode: 0755
+    mode: '0755'
   with_fileglob:
     - "{{ scripts_artifact_path }}/{{ tuxedo_user }}/*.j2"
 
-- name: "{{ tuxedo_user }} : Set permissions for new deployment files"
-  file:
+- name: "Set permissions for new deployment files : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "{{ new_deployment_files.path }}"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
     recurse: true
 
-- name: "{{ tuxedo_user }} : Check state of {{ tuxedo_user }} current deployment directory"
-  stat:
+- name: "Check state of current deployment directory : {{ tuxedo_user }}"
+  ansible.builtin.stat:
     path: "/home/{{ tuxedo_user }}/{{ deployment_dir }}"
   register: current_deployment_files
 
-- name: "{{ tuxedo_user }} : Stop SMS poll daemon processes"
+- name: "Stop SMS poll daemon processes : {{ tuxedo_user }}" # noqa ignore-errors
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/sms_poll_stop"
+  register: stop_sms_poll_daemon
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/sms_poll_stop"
   args:
     executable: /bin/bash
   ignore_errors: true
   when: sms_poll_daemon_enabled and tuxedo_user == "scud"
+  changed_when: "'SMS poll daemon not running' not in stop_sms_poll_daemon.stdout and stop_sms_poll_daemon.rc == 0"
 
-- name: "{{ tuxedo_user }} : Stop Tuxedo services"
+- name: "Stop Tuxedo services : {{ tuxedo_user }}" # noqa ignore-errors
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && timeout -s 9 20 tmshutdown -y"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && timeout -s 9 20 tmshutdown -y"
   args:
     executable: /bin/bash
   ignore_errors: true
   when: current_deployment_files.stat.exists
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Clear IPC facilities"
+- name: "Clear IPC facilities : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && zapipc"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && zapipc"
   args:
     executable: /bin/bash
   when: current_deployment_files.stat.exists
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Remove {{ tuxedo_user }} rollback directory if present"
-  file:
+- name: "Remove rollback directory if present : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "/home/{{ tuxedo_user }}/{{ rollback_dir }}"
     state: absent
 
-- name: "{{ tuxedo_user }} : Backup {{ tuxedo_user }} current deployment directory if one exists"
+- name: "Backup current deployment directory if one exists : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  command: "mv /home/{{ tuxedo_user }}/{{ deployment_dir }} /home/{{ tuxedo_user }}/{{ rollback_dir }}"
+  ansible.builtin.command: "mv /home/{{ tuxedo_user }}/{{ deployment_dir }} /home/{{ tuxedo_user }}/{{ rollback_dir }}"
   when: current_deployment_files.stat.exists
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Install new deployment files"
+- name: "Install new deployment files : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  command: "mv {{ new_deployment_files.path }} /home/{{ tuxedo_user }}/{{ deployment_dir }}"
+  ansible.builtin.command: "mv {{ new_deployment_files.path }} /home/{{ tuxedo_user }}/{{ deployment_dir }}"
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Lint Tuxedo ubbconfig file after variable population"
+- name: "Lint Tuxedo ubbconfig file after variable population : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && tmloadcf -n ubbconfig"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && tmloadcf -n ubbconfig"
   args:
     chdir: "/home/{{ tuxedo_user }}/{{ deployment_dir }}/config"
     executable: /bin/bash
   register: ubbconfig_lint
+  changed_when: false
 
-- name: "{{ tuxedo_user }} : Assert Tuxedo ubbconfig lint success"
-  assert:
+- name: "Assert Tuxedo ubbconfig lint success : {{ tuxedo_user }}"
+  ansible.builtin.assert:
     that:
       - ubbconfig_lint.rc == 0
     fail_msg: "Tuxedo ubbconfig file failed lint check"
     success_msg: "Tuxedo ubbconfig file passed lint check"
 
-- name: "{{ tuxedo_user }} : Generate Tuxedo binary tuxconfig file"
+- name: "Generate Tuxedo binary tuxconfig file : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && tmloadcf -y ubbconfig"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && tmloadcf -y ubbconfig"
   args:
     chdir: "/home/{{ tuxedo_user }}/{{ deployment_dir }}/config"
     executable: /bin/bash
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Lint Tuxedo dmconfig file after variable population"
+- name: "Lint Tuxedo dmconfig file after variable population : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && dmloadcf -n dmconfig"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && dmloadcf -n dmconfig"
   args:
     chdir: "/home/{{ tuxedo_user }}/{{ deployment_dir }}/config"
     executable: /bin/bash
   register: dmconfig_lint
+  changed_when: false
 
-- name: "{{ tuxedo_user }} : Assert Tuxedo dmconfig lint success"
-  assert:
+- name: "Assert Tuxedo dmconfig lint success : {{ tuxedo_user }}"
+  ansible.builtin.assert:
     that:
       - dmconfig_lint.rc == 0
     fail_msg: "Tuxedo dmconfig file failed lint check"
     success_msg: "Tuxedo dmconfig file passed lint check"
 
-- name: "{{ tuxedo_user }} : Generate Tuxedo binary bdmconfig file"
+- name: "Generate Tuxedo binary bdmconfig file : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && dmloadcf -y dmconfig"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && dmloadcf -y dmconfig"
   args:
     chdir: "/home/{{ tuxedo_user }}/{{ deployment_dir }}/config"
     executable: /bin/bash
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Configure recipient address for user-specific cron job emails"
-  cronvar:
+- name: "Configure recipient address for user-specific cron job emails : {{ tuxedo_user }}"
+  community.general.cronvar:
     name: MAILTO
     value: root@localhost
     user: "{{ tuxedo_user }}"
 
-- name: "{{ tuxedo_user }} : Create CloudWatch agent configuration file for Tuxedo service group"
-  template:
+- name: "Create CloudWatch agent configuration file for Tuxedo service group : {{ tuxedo_user }}"
+  ansible.builtin.template:
     src: templates/cloudwatch-config-service.json.j2
     dest: "{{ cloudwatch_agent.config_dir }}/cloudwatch-config-{{ tuxedo_user }}.json"
+    owner: cwagent
+    group: cwagent
+    mode: '0644'
     trim_blocks: false
 
-- name: "{{ tuxedo_user }} : Start Tuxedo services"
+- name: "Start Tuxedo services : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source $HOME/deployment/config/envfile && tmboot -y"
+  ansible.builtin.shell: "source $HOME/deployment/config/envfile && tmboot -y"
   args:
     executable: /bin/bash
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Start SMS poll daemon processes"
+- name: "Start SMS poll daemon processes : {{ tuxedo_user }}" # noqa ignore-errors
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/sms_poll_start"
+  register: start_sms_poll_daemon
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/sms_poll_start"
   args:
     executable: /bin/bash
   ignore_errors: true
   when: sms_poll_daemon_enabled and tuxedo_user == "scud"
+  changed_when: "'SMS poll daemon is already running' not in start_sms_poll_daemon.stdout and start_sms_poll_daemon.rc == 0"
 
-- name: "{{ tuxedo_user }} : Create autologin configuration for FTP client"
-  template:
+- name: "Create autologin configuration for FTP client : {{ tuxedo_user }}"
+  ansible.builtin.template:
     src: templates/netrc.j2
     dest: "/home/{{ tuxedo_user }}/.netrc"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    mode: 0400
+    mode: '0400'
   when: stats.enabled
   no_log: true
 
-- name: "{{ tuxedo_user }} : Create maintenance jobs"
-  cron:
+- name: "Create maintenance jobs : {{ tuxedo_user }}"
+  ansible.builtin.cron:
     name: "{{ item.name }}"
     day: "{{ item.day_of_month }}"
     weekday: "{{ item.day_of_week }}"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -4,11 +4,11 @@
   amazon.aws.ec2_metadata_facts:
 
 - name: Set host facts for passwd database
-  getent:
+  ansible.builtin.getent:
     database: passwd
 
 - name: Check required variables are set
-  assert:
+  ansible.builtin.assert:
     that:
       - tuxedo_service_users is defined and tuxedo_service_users | length > 0
       - environment_name is defined and environment_name | trim | length > 0
@@ -17,29 +17,40 @@
       - scripts_artifact_path is defined and scripts_artifact_path | trim | length > 0
     msg: "Required variable(s) empty or undefined"
 
+- name: Set common Tuxedo fact for domain suffix
+  ansible.builtin.set_fact:
+    tuxedo_common_suffix: "{{ ansible_facts.hostname
+      | regex_replace('development', 'dev')
+      | regex_replace('^fil-tuxedo-([A-Za-z]+)-(\\d+)$', 'FIL_\\2_\\1')
+      | upper }}"
+
 # The hostname is assumed to be in the format: fil-tuxedo-<environment>-<instance-index>; the environment
 # name 'development' is abbreviated to 'dev' to avoid exceeding the domain character limit
 - name: Set Tuxedo facts for config population
-  set_fact:
-     tuxedo_domain_id_suffix: "{{ ansible_facts.hostname | regex_replace('development', 'dev') | regex_replace('^fil-tuxedo-([A-Za-z].*)-(\\d+)$', 'FIL_\\2_\\1_DOM') | upper }}"
-     tuxedo_logical_machine_id_suffix: "{{ ansible_facts.hostname | regex_replace('development', 'dev') | regex_replace('^fil-tuxedo-([A-Za-z].*)-(\\d+)$', 'FIL_\\2_\\1_SRV') | upper }}"
-     tuxedo_local_domain_suffix: "{{ ansible_facts.hostname | regex_replace('development', 'dev') | regex_replace('^fil-tuxedo-([A-Za-z].*)-(\\d+)$', 'FIL_\\2_\\1_LOD') | upper }}"
+  ansible.builtin.set_fact:
+    tuxedo_domain_id_suffix: "{{ tuxedo_common_suffix + '_DOM' }}"
+    tuxedo_logical_machine_id_suffix: "{{ tuxedo_common_suffix + '_SRV' }}"
+    tuxedo_local_domain_suffix: "{{ tuxedo_common_suffix + '_LOD' }}"
 
 - name: Set CloudWatch agent facts for config population
-  set_fact:
+  ansible.builtin.set_fact:
     cloudwatch_agent: "{{ cloudwatch_agent_defaults | combine(cloudwatch_agent_overrides | default({})) }}"
     cloudwatch_log_stream_name: "{{ ansible_ec2_instance_id }}_{{ ansible_ec2_hostname }}"
     region: "{{ ansible_ec2_instance_identity_document_region }}"
 
 - name: Create CloudWatch agent primary configuration file
-  template:
+  ansible.builtin.template:
     src: templates/cloudwatch-config.json.j2
     dest: "{{ cloudwatch_agent.config_dir }}/cloudwatch-config.json"
+    owner: cwagent
+    group: cwagent
+    mode: '0644'
     trim_blocks: false
 
 - name: Start CloudWatch agent using primary configuration file
-  command:
+  ansible.builtin.command:
     cmd: "{{ cloudwatch_agent.path }} -a fetch-config -m ec2 -s -c file:{{ cloudwatch_agent.config_dir }}/cloudwatch-config.json"
+  changed_when: true
 
 - name: Using constructed variable suffixes
   ansible.builtin.debug:
@@ -50,82 +61,83 @@
     - tuxedo_local_domain_suffix
 
 - name: Create temporary directory for application artifact files
-  tempfile:
+  ansible.builtin.tempfile:
     state: directory
   register: application_artifact_files
 
 - name: Set permissions to allow service users to read from temporary directory
-  file:
+  ansible.builtin.file:
     path: "{{ application_artifact_files.path }}"
     owner: root
     group: "{{ tuxedo_service_group }}"
-    mode: 0755
+    mode: '0755'
 
 - name: Deploy and extract application artefact
-  unarchive:
+  ansible.builtin.unarchive:
     src: "{{ application_artifact_path }}"
     dest: "{{ application_artifact_files.path }}"
     remote_src: false
     owner: root
     group: "{{ tuxedo_service_group }}"
-    mode: 0755
+    mode: '0755'
 
 - name: Create Tuxedo logs directory
-  file:
+  ansible.builtin.file:
     path: "{{ tuxedo_logs_path }}"
     owner: root
     group: "{{ tuxedo_service_group }}"
-    mode: 0755
+    mode: '0755'
     state: directory
 
 - name: Create shared log rotation configuration for Tuxedo services
-  template:
+  ansible.builtin.template:
     src: templates/logrotate.tuxedo.conf.j2
     dest: "{{ tuxedo_log_rotation_config_path }}"
+    owner: root
+    group: root
+    mode: '0644'
 
-- import_tasks: cron.yml
+- name: Configure cron jobs
+  ansible.builtin.import_tasks: cron.yml
 
-- name: Allow logrotate to modify CloudWatch log
+- name: Allow logrotate to modify CloudWatch logs
   community.general.sefcontext:
-    target: "{{ item }}"
+    target: '/opt/aws/amazon-cloudwatch-agent/logs(/.*)?'
     setype: var_log_t
     state: present
-  loop:
-    - /opt/aws/amazon-cloudwatch-agent/logs
-    - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
-  register: selinux_context
 
-- name: Apply SELinux file context for CloudWatch log
-  command: "restorecon {{ item }}"
-  loop:
-    - /opt/aws/amazon-cloudwatch-agent/logs
-    - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
-  when: selinux_context.changed
+- name: Update SELinux security context
+  ansible.builtin.command: "restorecon -irv /opt/aws/amazon-cloudwatch-agent/logs"
+  register: cloudwatch_logs_selinux_context
+  changed_when: cloudwatch_logs_selinux_context.stdout != ""
 
-- import_tasks: tools.yml
+- name: Install additional tooling
+  ansible.builtin.import_tasks: tools.yml
 
 - name: Add host entry for SQL client connectivity
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/hosts
     line: "127.0.0.1   {{ ansible_facts.hostname }}"
 
-- include_tasks: deploy.yml
+- name: Deploy Tuxedo services
+  ansible.builtin.include_tasks: deploy.yml
   loop: "{{ tuxedo_service_users }}"
   loop_control:
     loop_var: tuxedo_user
 
 - name: Find application-specific CloudWatch configuration files
-  find:
+  ansible.builtin.find:
     paths: "{{ cloudwatch_agent.config_dir }}"
     patterns: 'cloudwatch-config-*.json'
   register: cloudwatch_configs
 
 - name: Add configuration for Tuxedo service group to CloudWatch agent
-  command:
+  ansible.builtin.command:
     cmd: "{{ cloudwatch_agent.path }} -a append-config -m ec2 -s -c file:{{ item.path }}"
   loop: "{{ cloudwatch_configs.files }}"
+  changed_when: true
 
 - name: Remove temporary directories
-  file:
+  ansible.builtin.file:
     path: "{{ application_artifact_files.path }}"
     state: absent

--- a/roles/deploy/tasks/tools.yml
+++ b/roles/deploy/tasks/tools.yml
@@ -1,14 +1,14 @@
 ---
 
 - name: Install additional tools for service maintenance scripts
-  yum:
+  ansible.builtin.dnf:
     state: present
     name:
       - ftp
       - mailx
 
 - name: Install printing support tools
-  yum:
+  ansible.builtin.dnf:
     state: present
     name:
       - cups
@@ -17,42 +17,46 @@
   notify:
     - Start printer support services
 
-- name: Check printer configuration exists
-  shell: "lpstat -p {{ sms_printer_name }}"
+- name: Check printer configuration exists # noqa ignore-errors
+  ansible.builtin.command: "lpstat -p {{ sms_printer_name }}"
   register: sms_printer_exists
   ignore_errors: true
+  changed_when: false
 
 - name: Add SMS printer configuration
-  shell: "lpadmin -p {{ sms_printer_name }} -E -v {{ sms_printer_uri }} -m {{ sms_printer_model }}"
+  ansible.builtin.command: "lpadmin -p {{ sms_printer_name }} -E -v {{ sms_printer_uri }} -m {{ sms_printer_model }}"
   when: sms_printer_enabled and sms_printer_exists is failed
+  changed_when: true
 
 - name: Set output path for SMS printer PDF files
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/cups/cups-pdf.conf
     regexp: '^Out '
     line: "Out {{ sms_printer_pdf_output_dir }}"
 
 - name: Remove SMS printer configuration
-  shell: "lpadmin -x {{ sms_printer_name }}"
+  ansible.builtin.command: "lpadmin -x {{ sms_printer_name }}"
   notify:
     - Stop printer support services
+  register: sms_printer_deleted
   when: not sms_printer_enabled and sms_printer_exists is succeeded
+  changed_when: sms_printer_deleted.rc == 0
 
 - name: Disable mailx inbuilt SMTP relay
-  replace:
+  ansible.builtin.replace:
     path: /etc/mail.rc
     regexp: '^(set smtp=.*)'
     replace: '#\1'
 
 - name: Configure Postfix mail transfer agent
-  template:
+  ansible.builtin.template:
     src: main.cf.j2
     dest: "{{ postfix_config_path }}"
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify:
     - Restart Postfix service
 
 - name: Flush handlers
-  meta: flush_handlers
+  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
These changes introduce significant refactoring improvements to the `deploy` role:

- Add descriptive names to plays
- Target multiple paths in `sefcontext` module task when setting SELinux file contexts
- Use `changed_when` to indicate when non-idempotent tasks (e.g. `command` and `shell`) result in a change or not
- Use fully qualified collection names (FQCNs) for all tasks
- Quote octal numbers (e.g. `'0755'`) to ensure consistent behaviour and avoid failures in loops and other circumstances
- Simplify `set_fact` domain suffix expressions and reduce code duplication
- Add Ansible Lint configuration for linting plays in pipeline at some future date 
- Replace standalone external roles with `companieshouse.general` collection
