### PR TITLE
Remove hashi_vault collection requirement

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -19,7 +19,5 @@ collections:
     version: "4.2.0"
   - name: community.general
     version: "4.8.0"
-  - name: community.hashi_vault
-    version: "3.3.1"
   - name: companieshouse.general
     version: "1.0.1"


### PR DESCRIPTION
The `hashi_vault` collection is now a dependency of the `companieshouse.general` collection and this change removes the direct dependency from the `requirements.yml` file.