### PR TITLE
Add desired continuous backup count argument

### DIFF
--- a/group_vars/tag_Name_fil_tuxedo_live_1
+++ b/group_vars/tag_Name_fil_tuxedo_live_1
@@ -318,7 +318,7 @@ informix_management_cron_jobs:
     minute: "0"
     hour: "7,14"
     month: "*"
-    script: "check_continuous_backups"
+    script: "check_continuous_backups 3"
 
 informix_host: instance-1.fil.tuxedo.live.heritage.aws.internal
 

--- a/group_vars/tag_Name_fil_tuxedo_live_2
+++ b/group_vars/tag_Name_fil_tuxedo_live_2
@@ -360,7 +360,7 @@ informix_management_cron_jobs:
     minute: "0"
     hour: "7,14"
     month: "*"
-    script: "check_continuous_backups"
+    script: "check_continuous_backups 3"
     disabled: true
 
 informix_host: instance-2.fil.tuxedo.live.heritage.aws.internal


### PR DESCRIPTION
After refactoring changes, the `check_continuous_backups` script now requires a desired continuous backup process count argument.