### PR TITLE
Refactor security group rules

### DIFF
--- a/groups/fil/instance.tf
+++ b/groups/fil/instance.tf
@@ -26,14 +26,14 @@ resource "aws_vpc_security_group_ingress_rule" "admin_ingress" {
   ip_protocol       = "tcp"
 }
 
-resource "aws_vpc_security_group_ingress_rule" "vb_app_ingress" {
-  for_each = setproduct(toset(local.visual_basic_app_cidrs), toset([3005, 6262, 6306]))
+resource "aws_vpc_security_group_ingress_rule" "visual_basic_app_ingress" {
+  for_each = local.visual_basic_app_security_group_rules
 
   security_group_id = aws_security_group.common.id
   description       = "Allow Informix HDR connectivity for Visual Basic services"
-  cidr_ipv4         = each.value[0]
-  from_port         = each.value[1]
-  to_port           = each.value[1]
+  cidr_ipv4         = each.value.cidr_ipv4
+  from_port         = each.value.port
+  to_port           = each.value.port
   ip_protocol       = "tcp"
 }
 

--- a/groups/fil/instance.tf
+++ b/groups/fil/instance.tf
@@ -27,7 +27,7 @@ resource "aws_vpc_security_group_ingress_rule" "admin_ingress" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "vb_app_ingress" {
-  for_each = setproduct(local.visual_basic_app_cidrs, toset([3005, 6262, 6306]))
+  for_each = setproduct(toset(local.visual_basic_app_cidrs), toset([3005, 6262, 6306]))
 
   security_group_id = aws_security_group.common.id
   description       = "Allow Informix HDR connectivity for Visual Basic services"

--- a/groups/fil/instance.tf
+++ b/groups/fil/instance.tf
@@ -50,7 +50,7 @@ resource "aws_vpc_security_group_ingress_rule" "chips_ingress" {
 
 resource "aws_vpc_security_group_ingress_rule" "ois_ingress" {
   for_each = {
-    for rule in local.ois_security_group_rules : "${rule.port}-${rule.cidr}" => rule
+    for rule in local.ois_security_group_rules : "${rule.service}-${rule.port}-${rule.cidr_ipv4}" => rule
   }
 
   security_group_id = aws_security_group.common.id
@@ -63,7 +63,7 @@ resource "aws_vpc_security_group_ingress_rule" "ois_ingress" {
 
 resource "aws_vpc_security_group_ingress_rule" "informix_ingress" {
   for_each = {
-    for rule in local.informix_hdr_security_group_rules : "${rule.port}-${rule.cidr}" => rule
+    for rule in local.informix_hdr_security_group_rules : "${rule.service}-${rule.port}-${rule.cidr_ipv4}" => rule
   }
 
   security_group_id = aws_security_group.common.id

--- a/groups/fil/instance.tf
+++ b/groups/fil/instance.tf
@@ -12,85 +12,75 @@ resource "aws_security_group" "common" {
   name   = "common-${local.common_resource_name}"
   vpc_id = data.aws_vpc.heritage.id
 
-  ingress {
-    description     = "Allow SSH connectivity for application deployments"
-    from_port       = 22
-    to_port         = 22
-    protocol        = "TCP"
-    prefix_list_ids = [data.aws_ec2_managed_prefix_list.shared_services_management.id]
-  }
-
-  ingress {
-    description = "Allow Informix HDR connectivity for Visual Basic services"
-    from_port   = 6262
-    to_port     = 6262
-    protocol    = "TCP"
-    cidr_blocks = local.visual_basic_app_cidrs
-  }
-
-  ingress {
-    description = "Allow Informix HDR connectivity for Visual Basic services"
-    from_port   = 6306
-    to_port     = 6306
-    protocol    = "TCP"
-    cidr_blocks = local.visual_basic_app_cidrs
-  }
-
-  ingress {
-    description = "Allow Informix HDR connectivity for Visual Basic services"
-    from_port   = 3005
-    to_port     = 3005
-    protocol    = "TCP"
-    cidr_blocks = local.visual_basic_app_cidrs
-  }
-
-  dynamic "ingress" {
-    for_each = var.tuxedo_services
-    iterator = service
-    content {
-      description = "Allow CHIPS connectivity for Tuxedo ${upper(service.key)} services"
-      from_port   = service.value
-      to_port     = service.value
-      protocol    = "TCP"
-      cidr_blocks = [var.chips_cidr]
-    }
-  }
-
-  dynamic "ingress" {
-    for_each = var.tuxedo_services
-    iterator = service
-    content {
-      description = "Allow OIS Tuxedo connectivity for Tuxedo ${upper(service.key)} services"
-      from_port   = service.value
-      to_port     = service.value
-      protocol    = "TCP"
-      cidr_blocks = data.aws_subnet.application[*].cidr_block
-    }
-  }
-
-  dynamic "ingress" {
-    for_each = var.informix_services
-    iterator = service
-    content {
-      description = "Allow Informix HDR connectivity for Tuxedo ${upper(service.key)} services"
-      from_port   = service.value
-      to_port     = service.value
-      protocol    = "TCP"
-      cidr_blocks = data.aws_subnet.application[*].cidr_block
-    }
-  }
-
-  egress {
-    description = "Allow outbound traffic"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   tags = merge(local.common_tags, {
     Name = "common-${local.common_resource_name}"
   })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "admin_ingress" {
+  security_group_id = aws_security_group.common.id
+  description       = "Allow SSH connectivity for application deployments"
+  prefix_list_id    = data.aws_ec2_managed_prefix_list.shared_services_management.id
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "vb_app_ingress" {
+  for_each = setproduct(local.visual_basic_app_cidrs, toset([3005, 6262, 6306]))
+
+  security_group_id = aws_security_group.common.id
+  description       = "Allow Informix HDR connectivity for Visual Basic services"
+  cidr_ipv4         = each.value[0]
+  from_port         = each.value[1]
+  to_port           = each.value[1]
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "chips_ingress" {
+  for_each = var.tuxedo_services
+
+  security_group_id = aws_security_group.common.id
+  description       = "Allow CHIPS connectivity for Tuxedo ${upper(each.key)} services"
+  cidr_ipv4         = var.chips_cidr
+  from_port         = each.value
+  to_port           = each.value
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ois_ingress" {
+  for_each = {
+    for rule in local.ois_security_group_rules : "${rule.port}-${rule.cidr}" => rule
+  }
+
+  security_group_id = aws_security_group.common.id
+  description       = "Allow OIS Tuxedo connectivity for Tuxedo ${upper(each.value.service)} services"
+  cidr_ipv4         = each.value.cidr_ipv4
+  from_port         = each.value.port
+  to_port           = each.value.port
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "informix_ingress" {
+  for_each = {
+    for rule in local.informix_hdr_security_group_rules : "${rule.port}-${rule.cidr}" => rule
+  }
+
+  security_group_id = aws_security_group.common.id
+  description       = "Allow Informix HDR connectivity for Tuxedo ${upper(each.value.service)} services"
+  cidr_ipv4         = each.value.cidr_ipv4
+  from_port         = each.value.port
+  to_port           = each.value.port
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "all_egress" {
+  security_group_id = aws_security_group.common.id
+  description       = "Allow all outbound traffic"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 0
+  to_port           = 0
+  ip_protocol       = "-1"
 }
 
 resource "aws_instance" "fil" {

--- a/groups/fil/locals.tf
+++ b/groups/fil/locals.tf
@@ -67,6 +67,12 @@ locals {
     local.iboss_cidr
   ]
 
+  visual_basic_app_ingress_ports = [
+    3005,
+    6262,
+    6306
+  ]
+
   ois_security_group_rules = flatten([
     for service_name, port_number in var.tuxedo_services : [
       for cidr_block in data.aws_subnet.application[*].cidr_block : {
@@ -86,4 +92,11 @@ locals {
       }
     ]
   ])
+
+  visual_basic_app_security_group_rules = {
+    for product in setproduct(toset(local.visual_basic_app_ingress_ports), toset(local.visual_basic_app_cidrs)) : "${product[0]}-${product[1]}" => {
+      port       = product[0]
+      cidr_ipv4  = product[1]
+    }
+  }
 }

--- a/groups/fil/locals.tf
+++ b/groups/fil/locals.tf
@@ -67,7 +67,7 @@ locals {
     local.iboss_cidr
   ]
 
-  ois_sg_rules = flatten([
+  ois_security_group_rules = flatten([
     for service_name, port_number in var.tuxedo_services : [
       for cidr_block in data.aws_subnet.application[*].cidr_block : {
         service   = service_name
@@ -77,7 +77,7 @@ locals {
     ]
   ])
 
-  informix_sg_rules = flatten([
+  informix_hdr_security_group_rules = flatten([
     for service_name, port_number in var.informix_services : [
       for cidr_block in data.aws_subnet.application[*].cidr_block : {
         service   = service_name

--- a/groups/fil/locals.tf
+++ b/groups/fil/locals.tf
@@ -66,4 +66,24 @@ locals {
     nonsensitive(data.vault_generic_secret.internal_cidrs.data["ipo_vpn"]),
     local.iboss_cidr
   ]
+
+  ois_sg_rules = flatten([
+    for service_name, port_number in var.tuxedo_services : [
+      for cidr_block in data.aws_subnet.application[*].cidr_block : {
+        service   = service_name
+        port      = port_number
+        cidr_ipv4 = cidr_block
+      }
+    ]
+  ])
+
+  informix_sg_rules = flatten([
+    for service_name, port_number in var.informix_services : [
+      for cidr_block in data.aws_subnet.application[*].cidr_block : {
+        service   = service_name
+        port      = port_number
+        cidr_ipv4 = cidr_block
+      }
+    ]
+  ])
 }


### PR DESCRIPTION
This change replaces all inline `ingress` and `egress` security group rules with `aws_vpc_security_group_ingress_rule` and `aws_vpc_security_group_egress_rule` resources.