### PR TITLE
Remove FTP configuration and autologin information

### DIFF
--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -257,16 +257,6 @@
   when: sms_poll_daemon_enabled and tuxedo_service == "scud"
   changed_when: "'SMS poll daemon is already running' not in start_sms_poll_daemon.stdout and start_sms_poll_daemon.rc == 0"
 
-- name: "Create autologin configuration for FTP client : {{ tuxedo_service }}"
-  ansible.builtin.template:
-    src: templates/netrc.j2
-    dest: "/home/{{ tuxedo_service }}/.netrc"
-    owner: "{{ tuxedo_service }}"
-    group: "{{ tuxedo_service }}"
-    mode: '0400'
-  when: stats.enabled
-  no_log: true
-
 - name: "Create maintenance jobs : {{ tuxedo_service }}"
   ansible.builtin.cron:
     name: "{{ item.name }}"

--- a/roles/deploy/tasks/tools.yml
+++ b/roles/deploy/tasks/tools.yml
@@ -4,7 +4,6 @@
   ansible.builtin.yum:
     state: present
     name:
-      - ftp
       - mailx
 
 - name: Install printing support tools # noqa fqcn[action-core]

--- a/roles/deploy/templates/netrc.j2
+++ b/roles/deploy/templates/netrc.j2
@@ -1,3 +1,0 @@
-{% for remote in stats_config.ftp_hosts %}
-machine {{ remote.host }} login {{ remote.username }} password {{ remote.password }}
-{% endfor %}


### PR DESCRIPTION
This update removes FTP related configuration used to transfer sage extract files to the E5 finance system. This mechanism is being replaced with a shared NFS mount. 

Resolves: `DVOP-3965`.